### PR TITLE
Feature/add transfer endpoints

### DIFF
--- a/Huobi.Net/Clients/FuturesApi/HuobiClientFuturesCoinApiAccount.cs
+++ b/Huobi.Net/Clients/FuturesApi/HuobiClientFuturesCoinApiAccount.cs
@@ -5,8 +5,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using CryptoExchange.Net;
 using CryptoExchange.Net.Objects;
+using Huobi.Net.Converters.Futures;
+using Huobi.Net.Enums.Futures;
 using Huobi.Net.Interfaces.Clients.FuturesApi;
 using Huobi.Net.Objects.Models.Futures;
+using Newtonsoft.Json;
 
 namespace Huobi.Net.Clients.FuturesApi
 {
@@ -16,6 +19,7 @@ namespace Huobi.Net.Clients.FuturesApi
         private const string BalancesEndpoint = "contract_account_info";
         private const string PositionsEndpoint = "contract_position_info";
         private const string SubAccountBalancesEndpoint = "contract_sub_account_info";
+        private const string TransferEndpoint = "futures/transfer";
 
         private readonly HuobiClientFuturesCoinApi _baseClient;
 
@@ -52,6 +56,19 @@ namespace Huobi.Net.Clients.FuturesApi
             parameters.AddOptionalParameter("symbol", symbol);
 
             return await _baseClient.SendHuobiFuturesRequest<IEnumerable<HuobiFuturesBalance>>(_baseClient.GetUrl(SubAccountBalancesEndpoint, "1"), HttpMethod.Post, ct, parameters, true, weight: 1).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<long>> TransferBetweenSpotAndFutures(string asset, decimal quantity, FutureTransferType transferType, CancellationToken ct = default)
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                { "currency", asset },
+                { "amount", quantity.ToString(CultureInfo.InvariantCulture) },
+                { "type", JsonConvert.SerializeObject(transferType, new FutureTransferTypeConverter(false)) }
+            };
+
+            return await _baseClient.SendHuobiFuturesRequest<long>(_baseClient.GetUrl(TransferEndpoint, "1"), HttpMethod.Post, ct, parameters, true, weight: 1).ConfigureAwait(false);
         }
     }
 }

--- a/Huobi.Net/Clients/FuturesApi/HuobiClientFuturesUsdtApiAccount.cs
+++ b/Huobi.Net/Clients/FuturesApi/HuobiClientFuturesUsdtApiAccount.cs
@@ -5,8 +5,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using CryptoExchange.Net;
 using CryptoExchange.Net.Objects;
+using Huobi.Net.Converters.Futures;
+using Huobi.Net.Enums.Futures;
 using Huobi.Net.Interfaces.Clients.FuturesApi;
 using Huobi.Net.Objects.Models.Futures;
+using Newtonsoft.Json;
 
 namespace Huobi.Net.Clients.FuturesApi
 {
@@ -21,6 +24,7 @@ namespace Huobi.Net.Clients.FuturesApi
         private const string PositionsCrossEndpoint = "swap_cross_position_info";
         private const string SubAccountBalancesIsolatedEndpoint = "swap_sub_account_info";
         private const string SubAccountBalancesCrossEndpoint = "swap_cross_sub_account_info";
+        private const string TransferEndpoint = "account/transfer";
 
         private readonly HuobiClientFuturesUsdtApi _baseClient;
 
@@ -87,6 +91,21 @@ namespace Huobi.Net.Clients.FuturesApi
             parameters.AddOptionalParameter("margin_account", marginAccount);
 
             return await _baseClient.SendHuobiFuturesRequest<IEnumerable<HuobiFuturesUsdtCrossBalance>>(_baseClient.GetUrl(SubAccountBalancesCrossEndpoint, Api, "1"), HttpMethod.Post, ct, parameters, true, weight: 1).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<long>> TransferBetweenSpotAndUsdtSwap(UsdtSwapTransferType from, UsdtSwapTransferType to, string asset, decimal quantity, string marginAccount, CancellationToken ct = default)
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                { "type", JsonConvert.SerializeObject(from, new UsdtSwapTransferTypeConverter(false)) },
+                { "to", JsonConvert.SerializeObject(to, new UsdtSwapTransferTypeConverter(false)) },
+                { "currency", asset },
+                { "amount", quantity.ToString(CultureInfo.InvariantCulture) },
+                { "margin-account", marginAccount }
+            };
+
+            return await _baseClient.SendHuobiFuturesRequest<long>(_baseClient.GetUrl(TransferEndpoint, "2"), HttpMethod.Post, ct, parameters, true, weight: 1).ConfigureAwait(false);
         }
     }
 }

--- a/Huobi.Net/Converters/Futures/FutureTransferTypeConverter.cs
+++ b/Huobi.Net/Converters/Futures/FutureTransferTypeConverter.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+using Huobi.Net.Enums.Futures;
+
+namespace Huobi.Net.Converters.Futures
+{
+    internal class FutureTransferTypeConverter : BaseConverter<FutureTransferType>
+    {
+        public FutureTransferTypeConverter() : this(true) { }
+
+        public FutureTransferTypeConverter(bool useQuotes) : base(useQuotes) { }
+
+        protected override List<KeyValuePair<FutureTransferType, string>> Mapping => new List<KeyValuePair<FutureTransferType, string>>
+        {
+            new KeyValuePair<FutureTransferType, string>(FutureTransferType.SpotToFutures, "pro-to-futures"),
+            new KeyValuePair<FutureTransferType, string>(FutureTransferType.FuturesToSpot, "futures-to-pro")
+        };
+    }
+}

--- a/Huobi.Net/Converters/Futures/UsdtSwapTransferTypeConverter.cs
+++ b/Huobi.Net/Converters/Futures/UsdtSwapTransferTypeConverter.cs
@@ -1,0 +1,19 @@
+﻿using CryptoExchange.Net.Converters;
+using Huobi.Net.Enums.Futures;
+using System.Collections.Generic;
+
+namespace Huobi.Net.Converters.Futures
+{
+    internal class UsdtSwapTransferTypeConverter : BaseConverter<UsdtSwapTransferType>
+    {
+        public UsdtSwapTransferTypeConverter() : this(true) { }
+
+        public UsdtSwapTransferTypeConverter(bool useQuotes) : base(useQuotes) { }
+
+        protected override List<KeyValuePair<UsdtSwapTransferType, string>> Mapping => new List<KeyValuePair<UsdtSwapTransferType, string>>
+        {
+            new KeyValuePair<UsdtSwapTransferType, string>(UsdtSwapTransferType.Spot, "spot"),
+            new KeyValuePair<UsdtSwapTransferType, string>(UsdtSwapTransferType.LinearSwap, "linear-swap")
+        };
+    }
+}

--- a/Huobi.Net/Converters/Swaps/CoinSwapTransferTypeConverter.cs
+++ b/Huobi.Net/Converters/Swaps/CoinSwapTransferTypeConverter.cs
@@ -1,0 +1,19 @@
+﻿using CryptoExchange.Net.Converters;
+using Huobi.Net.Enums.Swaps;
+using System.Collections.Generic;
+
+namespace Huobi.Net.Converters.Swaps
+{
+    internal class CoinSwapTransferTypeConverter : BaseConverter<CoinSwapTransferType>
+    {
+        public CoinSwapTransferTypeConverter() : this(true) { }
+
+        public CoinSwapTransferTypeConverter(bool useQuotes) : base(useQuotes) { }
+
+        protected override List<KeyValuePair<CoinSwapTransferType, string>> Mapping => new List<KeyValuePair<CoinSwapTransferType, string>>
+        {
+            new KeyValuePair<CoinSwapTransferType, string>(CoinSwapTransferType.Spot, "spot"),
+            new KeyValuePair<CoinSwapTransferType, string>(CoinSwapTransferType.Swap, "swap")
+        };
+    }
+}

--- a/Huobi.Net/Enums/Futures/FutureTransferType.cs
+++ b/Huobi.Net/Enums/Futures/FutureTransferType.cs
@@ -1,0 +1,17 @@
+﻿namespace Huobi.Net.Enums.Futures
+{
+    /// <summary>
+    /// Direction of transfer
+    /// </summary>
+    public enum FutureTransferType
+    {
+        /// <summary>
+        /// Spot to Futures
+        /// </summary>
+        SpotToFutures,
+        /// <summary>
+        /// Futures to Spot
+        /// </summary>
+        FuturesToSpot
+    }
+}

--- a/Huobi.Net/Enums/Futures/UsdtSwapTransferType.cs
+++ b/Huobi.Net/Enums/Futures/UsdtSwapTransferType.cs
@@ -1,0 +1,17 @@
+﻿namespace Huobi.Net.Enums.Futures
+{
+    /// <summary>
+    /// Transfer type
+    /// </summary>
+    public enum UsdtSwapTransferType
+    {
+        /// <summary>
+        /// Spot
+        /// </summary>
+        Spot,
+        /// <summary>
+        /// Linear Swap
+        /// </summary>
+        LinearSwap
+    }
+}

--- a/Huobi.Net/Enums/Swaps/CoinSwapTransferType.cs
+++ b/Huobi.Net/Enums/Swaps/CoinSwapTransferType.cs
@@ -1,0 +1,17 @@
+﻿namespace Huobi.Net.Enums.Swaps
+{
+    /// <summary>
+    /// Transfer Type
+    /// </summary>
+    public enum CoinSwapTransferType
+    {
+        /// <summary>
+        /// Spot
+        /// </summary>
+        Spot,
+        /// <summary>
+        /// Swap
+        /// </summary>
+        Swap
+    }
+}

--- a/Huobi.Net/Huobi.Net.xml
+++ b/Huobi.Net/Huobi.Net.xml
@@ -146,6 +146,9 @@
         <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesUsdtApiAccount.GetSubAccountBalancesCrossAsync(System.Int64,System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesUsdtApiAccount.TransferBetweenSpotAndUsdtSwap(Huobi.Net.Enums.Futures.UsdtSwapTransferType,Huobi.Net.Enums.Futures.UsdtSwapTransferType,System.String,System.Decimal,System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
         <member name="T:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesUsdtApiExchangeData">
             <inheritdoc />
         </member>
@@ -935,6 +938,21 @@
             Liquidate short positions
             </summary>
         </member>
+        <member name="T:Huobi.Net.Enums.Futures.UsdtSwapTransferType">
+            <summary>
+            Transfer type
+            </summary>
+        </member>
+        <member name="F:Huobi.Net.Enums.Futures.UsdtSwapTransferType.Spot">
+            <summary>
+            Spot
+            </summary>
+        </member>
+        <member name="F:Huobi.Net.Enums.Futures.UsdtSwapTransferType.LinearSwap">
+            <summary>
+            Linear Swap
+            </summary>
+        </member>
         <member name="T:Huobi.Net.Enums.InstrumentStatus">
             <summary>
             Status of an instrument
@@ -1496,6 +1514,7 @@
         <member name="M:Huobi.Net.Interfaces.Clients.FuturesApi.IHuobiClientFuturesCoinApiAccount.TransferBetweenSpotAndFutures(System.String,System.Decimal,Huobi.Net.Enums.Futures.FutureTransferType,System.Threading.CancellationToken)">
             <summary>
             Transfer margin between spot and futures account
+            <para><a href="https://huobiapi.github.io/docs/dm/v1/en/#transfer-margin-between-spot-account-and-future-account" /></para>
             </summary>
             <param name="asset">The asset to transfer</param>
             <param name="quantity">The amount to transfer</param>
@@ -1641,6 +1660,19 @@
             </summary>
             <param name="subId">The sub-account id</param>
             <param name="marginAccount">The margin account to query balances for, i.e. "USDT", returns all if null</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Huobi.Net.Interfaces.Clients.FuturesApi.IHuobiClientFuturesUsdtApiAccount.TransferBetweenSpotAndUsdtSwap(Huobi.Net.Enums.Futures.UsdtSwapTransferType,Huobi.Net.Enums.Futures.UsdtSwapTransferType,System.String,System.Decimal,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Transfer margin between spot and futures account
+            <para><a href="https://huobiapi.github.io/docs/usdt_swap/v1/en/#general-transfer-margin-between-spot-account-and-usdt-margined-contracts-account" /></para>
+            </summary>
+            <param name="from">The account to transfer from</param>
+            <param name="to">The account to transfer to</param>
+            <param name="asset">The asset to transfer</param>
+            <param name="quantity">The amount to transfer</param>
+            <param name="marginAccount">The margin account. For isolated margins, it should look something like "BTC-USDT", and for cross margin it should be something like "USDT"</param>
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>

--- a/Huobi.Net/Huobi.Net.xml
+++ b/Huobi.Net/Huobi.Net.xml
@@ -52,7 +52,16 @@
         <member name="T:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesCoinApiAccount">
             <inheritdoc />
         </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesCoinApiAccount.GetBalancesAsync(System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
         <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesCoinApiAccount.GetPositionsAsync(System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesCoinApiAccount.GetSubAccountBalancesAsync(System.Int64,System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesCoinApiAccount.TransferBetweenSpotAndFutures(System.String,System.Decimal,Huobi.Net.Enums.Futures.FutureTransferType,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="T:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesCoinApiExchangeData">
@@ -119,6 +128,24 @@
         <member name="T:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesUsdtApiAccount">
             <inheritdoc />
         </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesUsdtApiAccount.GetBalancesIsolatedAsync(System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesUsdtApiAccount.GetBalancesCrossAsync(System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesUsdtApiAccount.GetPositionsIsolatedAsync(System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesUsdtApiAccount.GetPositionsCrossAsync(System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesUsdtApiAccount.GetSubAccountBalancesIsolatedAsync(System.Int64,System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesUsdtApiAccount.GetSubAccountBalancesCrossAsync(System.Int64,System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
         <member name="T:Huobi.Net.Clients.FuturesApi.HuobiClientFuturesUsdtApiExchangeData">
             <inheritdoc />
         </member>
@@ -137,7 +164,13 @@
         <member name="T:Huobi.Net.Clients.FuturesApi.HuobiClientSwapsCoinApiAccount">
             <inheritdoc />
         </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientSwapsCoinApiAccount.GetBalancesAsync(System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
         <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientSwapsCoinApiAccount.GetPositionsAsync(System.String,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientSwapsCoinApiAccount.GetSubAccountBalancesAsync(System.Int64,System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
         <member name="T:Huobi.Net.Clients.HuobiClient">
@@ -461,6 +494,67 @@
         <member name="M:Huobi.Net.Clients.SpotApi.HuobiSocketClientSpotStreams.SubscribeToOrderDetailsUpdatesAsync(System.String,System.Action{CryptoExchange.Net.Sockets.DataEvent{Huobi.Net.Objects.Models.Socket.HuobiTradeUpdate}},System.Action{CryptoExchange.Net.Sockets.DataEvent{Huobi.Net.Objects.Models.Socket.HuobiOrderCancelationUpdate}},System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
+        <member name="T:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApi">
+            <inheritdoc />
+        </member>
+        <member name="E:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApi.OnOrderPlaced">
+            <summary>
+            Event triggered when an order is placed via this client
+            </summary>
+        </member>
+        <member name="E:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApi.OnOrderCanceled">
+            <summary>
+            Event triggered when an order is canceled via this client
+            </summary>
+        </member>
+        <member name="P:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApi.ExchangeName">
+            <inheritdoc />
+        </member>
+        <member name="P:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApi.Account">
+            <inheritdoc />
+        </member>
+        <member name="P:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApi.Trading">
+            <inheritdoc />
+        </member>
+        <member name="P:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApi.ExchangeData">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApi.CreateAuthenticationProvider(CryptoExchange.Net.Authentication.ApiCredentials)">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApi.GetUrl(System.String,System.String,System.String)">
+            <summary>
+            Construct url
+            </summary>
+            <param name="endpoint"></param>
+            <param name="api"></param>
+            <param name="version"></param>
+            <returns></returns>
+        </member>
+        <member name="M:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApi.GetServerTimestampAsync">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApi.GetTimeSyncInfo">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApi.GetTimeOffset">
+            <inheritdoc />
+        </member>
+        <member name="T:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApiExchangeData">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApiExchangeData.GetSymbolsAsync(System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApiExchangeData.GetServerTimeAsync(System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
+        <member name="T:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApiTrading">
+            <inheritdoc />
+        </member>
+        <member name="M:Huobi.Net.Clients.SwapsApi.HuobiClientSwapsCoinApiTrading.GetUserTradesAsync(System.String,System.Nullable{Huobi.Net.Enums.Futures.TradeType},System.Int32,System.Nullable{System.Int32},System.Nullable{System.Int32},System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
         <member name="T:Huobi.Net.Enums.AccountActivation">
             <summary>
             Account activation
@@ -769,6 +863,21 @@
         <member name="F:Huobi.Net.Enums.Futures.ContractType.Swap">
             <summary>
             Swap
+            </summary>
+        </member>
+        <member name="T:Huobi.Net.Enums.Futures.FutureTransferType">
+            <summary>
+            Direction of transfer
+            </summary>
+        </member>
+        <member name="F:Huobi.Net.Enums.Futures.FutureTransferType.SpotToFutures">
+            <summary>
+            Spot to Futures
+            </summary>
+        </member>
+        <member name="F:Huobi.Net.Enums.Futures.FutureTransferType.FuturesToSpot">
+            <summary>
+            Futures to Spot
             </summary>
         </member>
         <member name="T:Huobi.Net.Enums.Futures.Offset">
@@ -1374,6 +1483,26 @@
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>
+        <member name="M:Huobi.Net.Interfaces.Clients.FuturesApi.IHuobiClientFuturesCoinApiAccount.GetSubAccountBalancesAsync(System.Int64,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets a list of balances for a sub-account
+            <para><a href="https://huobiapi.github.io/docs/dm/v1/en/#query-a-single-sub-account-39-s-assets-information-2" /></para>
+            </summary>
+            <param name="subId">The sub-account id</param>
+            <param name="symbol">The id of the account to get the balances for</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Huobi.Net.Interfaces.Clients.FuturesApi.IHuobiClientFuturesCoinApiAccount.TransferBetweenSpotAndFutures(System.String,System.Decimal,Huobi.Net.Enums.Futures.FutureTransferType,System.Threading.CancellationToken)">
+            <summary>
+            Transfer margin between spot and futures account
+            </summary>
+            <param name="asset">The asset to transfer</param>
+            <param name="quantity">The amount to transfer</param>
+            <param name="transferType">The direction of the transfer</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
         <member name="T:Huobi.Net.Interfaces.Clients.FuturesApi.IHuobiClientFuturesCoinApi">
             <summary>
             COIN-M futures API endpoints
@@ -1492,6 +1621,26 @@
             <para><a href="https://huobiapi.github.io/docs/usdt_swap/v1/en/#cross-query-user-39-s-position-information" /></para>
             </summary>
             <param name="symbol">The id of the account to get the balances for</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Huobi.Net.Interfaces.Clients.FuturesApi.IHuobiClientFuturesUsdtApiAccount.GetSubAccountBalancesIsolatedAsync(System.Int64,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets a list of balances for a sub-account
+            <para><a href="https://huobiapi.github.io/docs/usdt_swap/v1/en/#isolated-query-a-single-sub-account-39-s-assets-information" /></para>
+            </summary>
+            <param name="subId">The sub-account id</param>
+            <param name="contractCode">The contract code to query balances for, returns all if null</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Huobi.Net.Interfaces.Clients.FuturesApi.IHuobiClientFuturesUsdtApiAccount.GetSubAccountBalancesCrossAsync(System.Int64,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets a list of balances for a sub-account
+            <para><a href="https://huobiapi.github.io/docs/usdt_swap/v1/en/#cross-query-a-batch-of-sub-account-39-s-assets-information" /></para>
+            </summary>
+            <param name="subId">The sub-account id</param>
+            <param name="marginAccount">The margin account to query balances for, i.e. "USDT", returns all if null</param>
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>
@@ -2252,8 +2401,18 @@
         <member name="M:Huobi.Net.Interfaces.Clients.SwapsApi.IHuobiClientSwapsCoinApiAccount.GetPositionsAsync(System.String,System.Threading.CancellationToken)">
             <summary>
             Gets a list of positions
-            <para><a href="https://huobiapi.github.io/docs/dm/v1/en/#query-user-s-position-information" /></para>
+            <para><a href="https://huobiapi.github.io/docs/coin_margined_swap/v1/en/#query-user-s-position-information" /></para>
             </summary>
+            <param name="symbol">The id of the account to get the balances for</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Huobi.Net.Interfaces.Clients.SwapsApi.IHuobiClientSwapsCoinApiAccount.GetSubAccountBalancesAsync(System.Int64,System.String,System.Threading.CancellationToken)">
+            <summary>
+            Gets a list of balances for a sub-account
+            <para><a href="https://huobiapi.github.io/docs/coin_margined_swap/v1/en/#query-assets-information-of-all-sub-accounts-under-the-master-account" /></para>
+            </summary>
+            <param name="subId">The sub-account id</param>
             <param name="symbol">The id of the account to get the balances for</param>
             <param name="ct">Cancellation token</param>
             <returns></returns>

--- a/Huobi.Net/Huobi.Net.xml
+++ b/Huobi.Net/Huobi.Net.xml
@@ -176,6 +176,9 @@
         <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientSwapsCoinApiAccount.GetSubAccountBalancesAsync(System.Int64,System.String,System.Threading.CancellationToken)">
             <inheritdoc />
         </member>
+        <member name="M:Huobi.Net.Clients.FuturesApi.HuobiClientSwapsCoinApiAccount.TransferBetweenSpotAndFutures(Huobi.Net.Enums.Swaps.CoinSwapTransferType,Huobi.Net.Enums.Swaps.CoinSwapTransferType,System.String,System.Decimal,System.Threading.CancellationToken)">
+            <inheritdoc />
+        </member>
         <member name="T:Huobi.Net.Clients.HuobiClient">
             <inheritdoc cref="T:Huobi.Net.Interfaces.Clients.IHuobiClient" />
         </member>
@@ -1211,6 +1214,21 @@
         <member name="F:Huobi.Net.Enums.SourceType.C2CMargin">
             <summary>
             c2c margin api
+            </summary>
+        </member>
+        <member name="T:Huobi.Net.Enums.Swaps.CoinSwapTransferType">
+            <summary>
+            Transfer Type
+            </summary>
+        </member>
+        <member name="F:Huobi.Net.Enums.Swaps.CoinSwapTransferType.Spot">
+            <summary>
+            Spot
+            </summary>
+        </member>
+        <member name="F:Huobi.Net.Enums.Swaps.CoinSwapTransferType.Swap">
+            <summary>
+            Swap
             </summary>
         </member>
         <member name="T:Huobi.Net.Enums.SymbolState">
@@ -2446,6 +2464,18 @@
             </summary>
             <param name="subId">The sub-account id</param>
             <param name="symbol">The id of the account to get the balances for</param>
+            <param name="ct">Cancellation token</param>
+            <returns></returns>
+        </member>
+        <member name="M:Huobi.Net.Interfaces.Clients.SwapsApi.IHuobiClientSwapsCoinApiAccount.TransferBetweenSpotAndFutures(Huobi.Net.Enums.Swaps.CoinSwapTransferType,Huobi.Net.Enums.Swaps.CoinSwapTransferType,System.String,System.Decimal,System.Threading.CancellationToken)">
+            <summary>
+            Transfer margin between spot and coin swap account
+            <para><a href="https://huobiapi.github.io/docs/coin_margined_swap/v1/en/#transfer-margin-between-spot-account-and-coin-margined-swap-account" /></para>
+            </summary>
+            <param name="from">The account to transfer from</param>
+            <param name="to">The account to transfer to</param>
+            <param name="asset">The asset to transfer</param>
+            <param name="quantity">The amount to transfer</param>
             <param name="ct">Cancellation token</param>
             <returns></returns>
         </member>

--- a/Huobi.Net/Interfaces/Clients/FuturesApi/IHuobiClientFuturesCoinAccount.cs
+++ b/Huobi.Net/Interfaces/Clients/FuturesApi/IHuobiClientFuturesCoinAccount.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using CryptoExchange.Net.Objects;
+using Huobi.Net.Enums.Futures;
 using Huobi.Net.Objects.Models.Futures;
 
 namespace Huobi.Net.Interfaces.Clients.FuturesApi
@@ -39,5 +40,16 @@ namespace Huobi.Net.Interfaces.Clients.FuturesApi
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         Task<WebCallResult<IEnumerable<HuobiFuturesBalance>>> GetSubAccountBalancesAsync(long subId, string? symbol = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Transfer margin between spot and futures account
+        /// <para><a href="https://huobiapi.github.io/docs/dm/v1/en/#transfer-margin-between-spot-account-and-future-account" /></para>
+        /// </summary>
+        /// <param name="asset">The asset to transfer</param>
+        /// <param name="quantity">The amount to transfer</param>
+        /// <param name="transferType">The direction of the transfer</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<long>> TransferBetweenSpotAndFutures(string asset, decimal quantity, FutureTransferType transferType, CancellationToken ct = default);
     }
 }

--- a/Huobi.Net/Interfaces/Clients/FuturesApi/IHuobiClientFuturesUsdtApiAccount.cs
+++ b/Huobi.Net/Interfaces/Clients/FuturesApi/IHuobiClientFuturesUsdtApiAccount.cs
@@ -2,8 +2,8 @@
 using System.Threading;
 using System.Threading.Tasks;
 using CryptoExchange.Net.Objects;
+using Huobi.Net.Enums.Futures;
 using Huobi.Net.Objects.Models.Futures;
-using Huobi.Net.Objects.Models.Swaps;
 
 namespace Huobi.Net.Interfaces.Clients.FuturesApi
 {
@@ -67,5 +67,18 @@ namespace Huobi.Net.Interfaces.Clients.FuturesApi
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         Task<WebCallResult<IEnumerable<HuobiFuturesUsdtCrossBalance>>> GetSubAccountBalancesCrossAsync(long subId, string? marginAccount = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Transfer margin between spot and futures account
+        /// <para><a href="https://huobiapi.github.io/docs/usdt_swap/v1/en/#general-transfer-margin-between-spot-account-and-usdt-margined-contracts-account" /></para>
+        /// </summary>
+        /// <param name="from">The account to transfer from</param>
+        /// <param name="to">The account to transfer to</param>
+        /// <param name="asset">The asset to transfer</param>
+        /// <param name="quantity">The amount to transfer</param>
+        /// <param name="marginAccount">The margin account. For isolated margins, it should look something like "BTC-USDT", and for cross margin it should be something like "USDT"</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<long>> TransferBetweenSpotAndUsdtSwap(UsdtSwapTransferType from, UsdtSwapTransferType to, string asset, decimal quantity, string marginAccount, CancellationToken ct = default);
     }
 }

--- a/Huobi.Net/Interfaces/Clients/SwapsApi/IHuobiClientSwapsCoinApiAccount.cs
+++ b/Huobi.Net/Interfaces/Clients/SwapsApi/IHuobiClientSwapsCoinApiAccount.cs
@@ -2,6 +2,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using CryptoExchange.Net.Objects;
+using Huobi.Net.Enums.Swaps;
 using Huobi.Net.Objects.Models.Swaps;
 
 namespace Huobi.Net.Interfaces.Clients.SwapsApi
@@ -38,5 +39,17 @@ namespace Huobi.Net.Interfaces.Clients.SwapsApi
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
         Task<WebCallResult<IEnumerable<HuobiSwapsBalance>>> GetSubAccountBalancesAsync(long subId, string? symbol = null, CancellationToken ct = default);
+
+        /// <summary>
+        /// Transfer margin between spot and coin swap account
+        /// <para><a href="https://huobiapi.github.io/docs/coin_margined_swap/v1/en/#transfer-margin-between-spot-account-and-coin-margined-swap-account" /></para>
+        /// </summary>
+        /// <param name="from">The account to transfer from</param>
+        /// <param name="to">The account to transfer to</param>
+        /// <param name="asset">The asset to transfer</param>
+        /// <param name="quantity">The amount to transfer</param>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<long>> TransferBetweenSpotAndFutures(CoinSwapTransferType from, CoinSwapTransferType to, string asset, decimal quantity, CancellationToken ct = default);
     }
 }


### PR DESCRIPTION
This PR is to add transfer endpoints to go from the Spot pot to Coin Futures, Coin Swaps and USDT-whatever-this-is and back.
2 of 3 endpoints seem to have the exact same address, no idea what's going on there!